### PR TITLE
Silently pass a nil if authorize failure

### DIFF
--- a/lib/bullhorn/rest/authentication.rb
+++ b/lib/bullhorn/rest/authentication.rb
@@ -41,6 +41,7 @@ module Authentication
     }
     res = auth_conn.get url, params
     location = res.headers['location']
+    return res.body if location.nil? #Return the error body
     self.auth_code = CGI::parse(URI(location).query)["code"].first
   end
 


### PR DESCRIPTION
The raised error is a side effect, it has nothing to do with a failure to authorize. Better to let 'authenticated?' do its job and return a false.
